### PR TITLE
Upgrade dependency active_model_serializers

### DIFF
--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.10.4"
+  spec.add_dependency "active_model_serializers", "0.10.3"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.10.10"
+  spec.add_dependency "active_model_serializers", "0.10.4"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.10.0"
+  spec.add_dependency "active_model_serializers", "0.10.10"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.10.0rc5"
+  spec.add_dependency "active_model_serializers", "0.10.0"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"

--- a/active_model_serializers_matchers.gemspec
+++ b/active_model_serializers_matchers.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency "active_model_serializers", "0.10.3"
+  spec.add_dependency "active_model_serializers", "0.10.2"
   spec.add_dependency "rspec", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
Upgrade dependency where is compatible with rails 5.0 and ruby 2.4.9.